### PR TITLE
fix: Correct range check when replacing node in address

### DIFF
--- a/src/csp_py/address.py
+++ b/src/csp_py/address.py
@@ -53,8 +53,8 @@ class CspAddress:
         return CspAddress(address=network_address, netbits=self.netbits, version=self.version)
     
     def with_node_address(self, node: int) -> 'CspAddress':
-        max_node = self.node_mask - 1
-        if not (0 <= node < max_node):
-            raise ValueError(f"Invalid node address: {node}")
+        max_node = self.node_mask
+        if not (0 <= node <= max_node):
+            raise ValueError(f"Invalid node address: {node}. Must be between 0 and {max_node}.")
 
         return CspAddress(address=self.network_address.address | node, netbits=self.netbits, version=self.version)

--- a/src/tests/test_address_model.py
+++ b/src/tests/test_address_model.py
@@ -16,6 +16,7 @@ def test_csp_v2() -> None:
     assert CspAddress(address=0x35BA, netbits=6, version=2).node_mask == 0x00FF
     assert CspAddress(address=0x35BA, netbits=6, version=2).network_address == CspAddress(address=0x3500, netbits=6, version=2)
     assert CspAddress(address=0x35BA, netbits=6, version=2).with_node_address(0xAC) == CspAddress(address=0x35AC, netbits=6, version=2)
+    assert CspAddress(address=0x35BA, netbits=6, version=2).with_node_address(0xFF) == CspAddress(address=0x35FF, netbits=6, version=2)
 
 
 def test_csp_v2_wrong_netbits() -> None:
@@ -49,6 +50,7 @@ def test_csp_v1() -> None:
     assert CspAddress(address=0b11011, netbits=3, version=1).node_mask == 0b00011
     assert CspAddress(address=0b11011, netbits=3, version=1).network_address == CspAddress(address=0b11000, netbits=3, version=1)
     assert CspAddress(address=0b11011, netbits=2, version=1).with_node_address(0b101) == CspAddress(address=0b11101, netbits=2, version=1)
+    assert CspAddress(address=0b11011, netbits=2, version=1).with_node_address(0b111) == CspAddress(address=0b11111, netbits=2, version=1)
 
 
 def test_csp_v1_wrong_netbits() -> None:


### PR DESCRIPTION
Off-by-one when calling "with_node_address" on CspAddress. Node mask is already set to number of 1 starting from LSBit and matches maximum node address.